### PR TITLE
fix: prevent deletion of facilities/equipment with active reservation…

### DIFF
--- a/backend/cefrs-backend/src/main/java/com/campus/facility_reservation/service/EquipmentService.java
+++ b/backend/cefrs-backend/src/main/java/com/campus/facility_reservation/service/EquipmentService.java
@@ -3,19 +3,21 @@ package com.campus.facility_reservation.service;
 import com.campus.facility_reservation.model.Equipment;
 import com.campus.facility_reservation.model.Equipment.EquipmentCategory;
 import com.campus.facility_reservation.model.Equipment.EquipmentStatus;
+import com.campus.facility_reservation.model.EquipmentBorrowing;
+import com.campus.facility_reservation.model.EquipmentBorrowing.BorrowingStatus;
 import com.campus.facility_reservation.dto.EquipmentDTO;
 import com.campus.facility_reservation.dto.EquipmentRequestDTO;
 import com.campus.facility_reservation.repository.EquipmentRepository;
+import com.campus.facility_reservation.repository.EquipmentBorrowingRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import com.campus.facility_reservation.annotation.Audited;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 import com.campus.facility_reservation.dto.SuggestedEquipmentDTO;
-import com.campus.facility_reservation.repository.EquipmentBorrowingRepository;
-import java.time.LocalDate;
 
 @Service
 @RequiredArgsConstructor
@@ -51,6 +53,15 @@ public class EquipmentService {
     @Audited(action = "CREATE", table = "equipment")
     @Transactional
     public EquipmentDTO createEquipment(EquipmentRequestDTO request) {
+        // Check for duplicate names
+        List<Equipment> existingEquipment = equipmentRepository.findByNameContainingIgnoreCase(request.getName());
+        boolean exactMatch = existingEquipment.stream()
+                .anyMatch(e -> e.getName().trim().equalsIgnoreCase(request.getName().trim()));
+
+        if (exactMatch) {
+            throw new RuntimeException("Equipment with the name '" + request.getName() + "' already exists. Please use a different name.");
+        }
+
         Equipment equipment = new Equipment();
         equipment.setName(request.getName());
         equipment.setCategory(EquipmentCategory.valueOf(request.getCategory().toUpperCase()));
@@ -76,27 +87,50 @@ public class EquipmentService {
     @Transactional
     public EquipmentDTO updateEquipment(Long id, EquipmentRequestDTO request) {
         Equipment equipment = equipmentRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Equipment not found"));
+                .orElseThrow(() -> new RuntimeException("Equipment not found with ID: " + id));
+
+        // Check for duplicate names (excluding current equipment)
+        List<Equipment> existingEquipment = equipmentRepository.findByNameContainingIgnoreCase(request.getName());
+        boolean duplicateExists = existingEquipment.stream()
+                .anyMatch(e -> !e.getId().equals(id) && e.getName().trim().equalsIgnoreCase(request.getName().trim()));
+
+        if (duplicateExists) {
+            throw new RuntimeException("Equipment with the name '" + request.getName() + "' already exists. Please use a different name.");
+        }
+
+        // CRITICAL VALIDATION: Check if reducing quantity below borrowed amount
+        Integer currentBorrowed = borrowingRepository.getTotalBorrowedQuantity(equipment);
+        int totalBorrowed = (currentBorrowed != null) ? currentBorrowed : 0;
+
+        if (request.getQuantityTotal() < totalBorrowed) {
+            throw new RuntimeException(
+                "Cannot reduce total quantity to " + request.getQuantityTotal() +
+                " because " + totalBorrowed + " item(s) are currently borrowed or approved for borrowing. " +
+                "The new quantity must be at least " + totalBorrowed + ". " +
+                "Please wait for items to be returned or cancel approved borrowings before reducing quantity."
+            );
+        }
+
+        // Calculate new available quantity
+        int newAvailable = request.getQuantityTotal() - totalBorrowed;
+        if (newAvailable < 0) {
+            newAvailable = 0;
+        }
 
         equipment.setName(request.getName());
         equipment.setCategory(EquipmentCategory.valueOf(request.getCategory().toUpperCase()));
         equipment.setQuantityTotal(request.getQuantityTotal());
+        equipment.setQuantityAvailable(newAvailable); // Recalculate based on borrowed items
         equipment.setDescription(request.getDescription());
         equipment.setImageUrl(request.getImageUrl());
         equipment.setLocation(request.getLocation());
         equipment.setSupplier(request.getSupplier());
 
-        // IMPORTANT: Ensure you handle quantityAvailable if passed in request
-        if (request.getQuantityAvailable() != null) {
-            equipment.setQuantityAvailable(request.getQuantityAvailable());
-        }
-
-        // IMPORTANT: Set status from request, don't calculate it
+        // Update status from request if provided
         if (request.getStatus() != null && !request.getStatus().isEmpty()) {
             equipment.setStatus(EquipmentStatus.valueOf(request.getStatus().toUpperCase()));
         }
 
-        // DO NOT auto-set status based on quantity here
         Equipment updated = equipmentRepository.save(equipment);
         return convertToDTO(updated);
     }
@@ -104,6 +138,101 @@ public class EquipmentService {
     @Audited(action = "DELETE", table = "equipment")
     @Transactional
     public void deleteEquipment(Long id) {
+        Equipment equipment = equipmentRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Equipment not found with ID: " + id));
+
+        // CRITICAL VALIDATION: Check for active or upcoming borrowings
+        List<EquipmentBorrowing> allBorrowings = borrowingRepository.findByEquipmentOrderByBorrowDateDesc(equipment);
+
+        // Check for APPROVED borrowings (confirmed but not yet borrowed)
+        List<EquipmentBorrowing> approvedBorrowings = allBorrowings.stream()
+                .filter(b -> b.getStatus() == BorrowingStatus.APPROVED)
+                .collect(Collectors.toList());
+
+        if (!approvedBorrowings.isEmpty()) {
+            int totalApprovedQty = approvedBorrowings.stream()
+                    .mapToInt(EquipmentBorrowing::getQuantity)
+                    .sum();
+
+            throw new RuntimeException(
+                "Cannot delete equipment '" + equipment.getName() + "': " +
+                totalApprovedQty + " item(s) across " + approvedBorrowings.size() + " borrowing(s) have been approved for future use. " +
+                "Please cancel or wait for these approved borrowings to complete before deleting."
+            );
+        }
+
+        // Check for BORROWED items (currently in use)
+        List<EquipmentBorrowing> borrowedItems = allBorrowings.stream()
+                .filter(b -> b.getStatus() == BorrowingStatus.BORROWED)
+                .collect(Collectors.toList());
+
+        if (!borrowedItems.isEmpty()) {
+            int totalBorrowedQty = borrowedItems.stream()
+                    .mapToInt(EquipmentBorrowing::getQuantity)
+                    .sum();
+
+            throw new RuntimeException(
+                "Cannot delete equipment '" + equipment.getName() + "': " +
+                totalBorrowedQty + " item(s) are currently borrowed by " + borrowedItems.size() + " user(s). " +
+                "Please wait for all items to be returned before deleting this equipment."
+            );
+        }
+
+        // Check for PENDING borrowings (awaiting approval)
+        List<EquipmentBorrowing> pendingBorrowings = allBorrowings.stream()
+                .filter(b -> b.getStatus() == BorrowingStatus.PENDING)
+                .collect(Collectors.toList());
+
+        if (!pendingBorrowings.isEmpty()) {
+            throw new RuntimeException(
+                "Cannot delete equipment '" + equipment.getName() + "': " +
+                "There are " + pendingBorrowings.size() + " pending borrowing request(s) awaiting approval. " +
+                "Please process or cancel all pending requests before deleting this equipment."
+            );
+        }
+
+        // Check for OVERDUE borrowings
+        List<EquipmentBorrowing> overdueBorrowings = allBorrowings.stream()
+                .filter(b -> b.getStatus() == BorrowingStatus.OVERDUE)
+                .collect(Collectors.toList());
+
+        if (!overdueBorrowings.isEmpty()) {
+            int totalOverdueQty = overdueBorrowings.stream()
+                    .mapToInt(EquipmentBorrowing::getQuantity)
+                    .sum();
+
+            throw new RuntimeException(
+                "Cannot delete equipment '" + equipment.getName() + "': " +
+                totalOverdueQty + " item(s) are overdue across " + overdueBorrowings.size() + " borrowing(s). " +
+                "Please resolve all overdue borrowings before deleting this equipment."
+            );
+        }
+
+        // Check for any other non-terminal borrowings (WAITLISTED)
+        List<EquipmentBorrowing> otherActiveBorrowings = allBorrowings.stream()
+                .filter(b -> b.getStatus() != BorrowingStatus.RETURNED &&
+                             b.getStatus() != BorrowingStatus.CANCELLED &&
+                             b.getStatus() != BorrowingStatus.REJECTED)
+                .collect(Collectors.toList());
+
+        if (!otherActiveBorrowings.isEmpty()) {
+            throw new RuntimeException(
+                "Cannot delete equipment '" + equipment.getName() + "': " +
+                "There are " + otherActiveBorrowings.size() + " active borrowing(s) in various states. " +
+                "Please ensure all borrowings are returned, cancelled, or rejected before deleting."
+            );
+        }
+
+        // Additional safety check: verify quantityAvailable equals quantityTotal
+        if (!equipment.getQuantityAvailable().equals(equipment.getQuantityTotal())) {
+            throw new RuntimeException(
+                "Cannot delete equipment '" + equipment.getName() + "': " +
+                "Only " + equipment.getQuantityAvailable() + " out of " + equipment.getQuantityTotal() + " items are available. " +
+                "Some items may still be in use. Please verify all items are returned."
+            );
+        }
+
+        // If we reach here, equipment has no active borrowings and can be safely deleted
         equipmentRepository.deleteById(id);
     }
 
@@ -126,7 +255,7 @@ public class EquipmentService {
      * This is a simple heuristic: return other equipment in the same category that have
      * quantityAvailable > 0 (excluding the original equipment).
      */
-        public SuggestedEquipmentDTO getSuggestedEquipment(Long id, String borrowDate, String expectedReturnDate) {
+    public SuggestedEquipmentDTO getSuggestedEquipment(Long id, String borrowDate, String expectedReturnDate) {
         Equipment equipment = equipmentRepository.findById(id)
             .orElseThrow(() -> new RuntimeException("Equipment not found"));
 
@@ -152,5 +281,5 @@ public class EquipmentService {
         dto.setReason("Not enough equipment available for the requested date range");
         dto.setSuggestedEquipment(suggestions);
         return dto;
-        }
+    }
 }

--- a/backend/cefrs-backend/src/main/java/com/campus/facility_reservation/service/FacilityReservationService.java
+++ b/backend/cefrs-backend/src/main/java/com/campus/facility_reservation/service/FacilityReservationService.java
@@ -2,6 +2,7 @@ package com.campus.facility_reservation.service;
 
 import com.campus.facility_reservation.model.*;
 import com.campus.facility_reservation.model.FacilityReservation.ReservationStatus;
+import com.campus.facility_reservation.model.Facility.FacilityStatus;
 import com.campus.facility_reservation.dto.FacilityReservationDTO;
 import com.campus.facility_reservation.dto.FacilityReservationRequestDTO;
 import com.campus.facility_reservation.dto.ReservationApprovalDTO;
@@ -165,6 +166,11 @@ public class FacilityReservationService {
                     reservationRepository.save(other);
                 }
             }
+
+            // **UPDATE FACILITY STATUS TO RESERVED**
+            Facility facility = reservation.getFacility();
+            facility.setStatus(FacilityStatus.RESERVED);
+            facilityRepository.save(facility);
         }
 
         reservation.setStatus(status);
@@ -182,13 +188,25 @@ public class FacilityReservationService {
         }
 
         // If this reservation was APPROVED before and is now being changed to a
-        // non-APPROVED
-        // terminal state, promote the next WAITLISTED reservation (if any) for this
-        // slot.
+        // non-APPROVED terminal state, update facility status and promote waitlist
         if (oldStatus == ReservationStatus.APPROVED
                 && (status == ReservationStatus.CANCELLED
                         || status == ReservationStatus.REJECTED
                         || status == ReservationStatus.COMPLETED)) {
+
+            // **CHECK IF FACILITY HAS OTHER APPROVED RESERVATIONS**
+            Facility facility = reservation.getFacility();
+            List<FacilityReservation> otherApprovedReservations = reservationRepository
+                    .findByFacilityOrderByReservationDateAscStartTimeAsc(facility).stream()
+                    .filter(r -> r.getStatus() == ReservationStatus.APPROVED && !r.getId().equals(reservation.getId()))
+                    .collect(Collectors.toList());
+
+            // If no other approved reservations, set facility back to AVAILABLE
+            if (otherApprovedReservations.isEmpty()) {
+                facility.setStatus(FacilityStatus.AVAILABLE);
+                facilityRepository.save(facility);
+            }
+
             promoteNextFromWaitlist(reservation);
         }
 
@@ -218,12 +236,26 @@ public class FacilityReservationService {
             throw new RuntimeException("Reservation cannot be marked as completed in its current status");
         }
 
+        ReservationStatus oldStatus = reservation.getStatus();
         reservation.setStatus(ReservationStatus.COMPLETED);
         FacilityReservation updated = reservationRepository.save(reservation);
 
-        // When a reservation is completed, free the slot for the next in the waiting
-        // list
-        promoteNextFromWaitlist(reservation);
+        // When a reservation is completed and it was APPROVED, check facility status
+        if (oldStatus == ReservationStatus.APPROVED) {
+            Facility facility = reservation.getFacility();
+            List<FacilityReservation> otherApprovedReservations = reservationRepository
+                    .findByFacilityOrderByReservationDateAscStartTimeAsc(facility).stream()
+                    .filter(r -> r.getStatus() == ReservationStatus.APPROVED && !r.getId().equals(reservation.getId()))
+                    .collect(Collectors.toList());
+
+            // If no other approved reservations, set facility back to AVAILABLE
+            if (otherApprovedReservations.isEmpty()) {
+                facility.setStatus(FacilityStatus.AVAILABLE);
+                facilityRepository.save(facility);
+            }
+
+            promoteNextFromWaitlist(reservation);
+        }
 
         return convertToDTO(updated);
     }
@@ -242,8 +274,20 @@ public class FacilityReservationService {
         reservation.setStatus(ReservationStatus.CANCELLED);
         reservationRepository.save(reservation);
 
-        // Only promote from waitlist if an APPROVED reservation has been cancelled
+        // Only update facility status and promote from waitlist if an APPROVED reservation has been cancelled
         if (oldStatus == ReservationStatus.APPROVED) {
+            Facility facility = reservation.getFacility();
+            List<FacilityReservation> otherApprovedReservations = reservationRepository
+                    .findByFacilityOrderByReservationDateAscStartTimeAsc(facility).stream()
+                    .filter(r -> r.getStatus() == ReservationStatus.APPROVED && !r.getId().equals(reservation.getId()))
+                    .collect(Collectors.toList());
+
+            // If no other approved reservations, set facility back to AVAILABLE
+            if (otherApprovedReservations.isEmpty()) {
+                facility.setStatus(FacilityStatus.AVAILABLE);
+                facilityRepository.save(facility);
+            }
+
             promoteNextFromWaitlist(reservation);
         }
     }
@@ -260,10 +304,8 @@ public class FacilityReservationService {
 
     /**
      * Promote the next WAITLISTED reservation (if any) that overlaps the given
-     * reservation's
-     * facility, date, and time range. The promoted reservation is moved back to
-     * PENDING so
-     * that an admin can review and approve it explicitly.
+     * reservation's facility, date, and time range. The promoted reservation is moved back to
+     * PENDING so that an admin can review and approve it explicitly.
      */
     private void promoteNextFromWaitlist(FacilityReservation releasedReservation) {
         List<FacilityReservation> waitlisted = reservationRepository.findOverlappingByStatusOrderByCreatedAtAsc(
@@ -295,8 +337,7 @@ public class FacilityReservationService {
         // Get all facilities
         List<Facility> allFacilities = facilityRepository.findAll();
 
-        // Filter for available facilities with same or greater capacity and similar
-        // type
+        // Filter for available facilities with same or greater capacity and similar type
         List<FacilityDTO> suggestedFacilities = new ArrayList<>();
 
         for (Facility facility : allFacilities) {
@@ -346,7 +387,7 @@ public class FacilityReservationService {
                 facility.getCapacity(),
                 facility.getDescription(),
                 facility.getImageUrl(),
-                "AVAILABLE");
+                facility.getStatus().name());
     }
 
     private FacilityReservationDTO convertToDTO(FacilityReservation reservation) {

--- a/backend/cefrs-backend/src/main/java/com/campus/facility_reservation/service/FacilityService.java
+++ b/backend/cefrs-backend/src/main/java/com/campus/facility_reservation/service/FacilityService.java
@@ -3,13 +3,18 @@ package com.campus.facility_reservation.service;
 import com.campus.facility_reservation.model.Facility;
 import com.campus.facility_reservation.model.Facility.FacilityStatus;
 import com.campus.facility_reservation.model.Facility.FacilityType;
+import com.campus.facility_reservation.model.FacilityReservation;
+import com.campus.facility_reservation.model.FacilityReservation.ReservationStatus;
 import com.campus.facility_reservation.dto.FacilityDTO;
 import com.campus.facility_reservation.repository.FacilityRepository;
+import com.campus.facility_reservation.repository.FacilityReservationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import com.campus.facility_reservation.annotation.Audited;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -18,6 +23,7 @@ import java.util.stream.Collectors;
 public class FacilityService {
 
     private final FacilityRepository facilityRepository;
+    private final FacilityReservationRepository reservationRepository;
 
     public List<FacilityDTO> getAllFacilities() {
         return facilityRepository.findAll().stream()
@@ -53,6 +59,15 @@ public class FacilityService {
     @Audited(action = "CREATE", table = "facility")
     @Transactional
     public FacilityDTO createFacility(FacilityDTO facilityDTO) {
+        // Check for duplicate names
+        List<Facility> existingFacilities = facilityRepository.findByNameContainingIgnoreCase(facilityDTO.getName());
+        boolean exactMatch = existingFacilities.stream()
+                .anyMatch(f -> f.getName().trim().equalsIgnoreCase(facilityDTO.getName().trim()));
+
+        if (exactMatch) {
+            throw new RuntimeException("A facility with the name '" + facilityDTO.getName() + "' already exists. Please use a different name.");
+        }
+
         Facility facility = new Facility();
         facility.setName(facilityDTO.getName());
         facility.setType(FacilityType.valueOf(facilityDTO.getType().toUpperCase()));
@@ -77,7 +92,33 @@ public class FacilityService {
     @Transactional
     public FacilityDTO updateFacility(Long id, FacilityDTO facilityDTO) {
         Facility facility = facilityRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Facility not found"));
+                .orElseThrow(() -> new RuntimeException("Facility not found with ID: " + id));
+
+        // Check for duplicate names (excluding current facility)
+        List<Facility> existingFacilities = facilityRepository.findByNameContainingIgnoreCase(facilityDTO.getName());
+        boolean duplicateExists = existingFacilities.stream()
+                .anyMatch(f -> !f.getId().equals(id) && f.getName().trim().equalsIgnoreCase(facilityDTO.getName().trim()));
+
+        if (duplicateExists) {
+            throw new RuntimeException("A facility with the name '" + facilityDTO.getName() + "' already exists. Please use a different name.");
+        }
+
+        // If reducing capacity, check if it would affect active reservations
+        if (facilityDTO.getCapacity() < facility.getCapacity()) {
+            // Get active reservations for this facility
+            List<FacilityReservation> activeReservations = reservationRepository
+                    .findByFacilityOrderByReservationDateAscStartTimeAsc(facility).stream()
+                    .filter(r -> r.getStatus() == ReservationStatus.APPROVED ||
+                                 r.getStatus() == ReservationStatus.PENDING)
+                    .collect(Collectors.toList());
+
+            if (!activeReservations.isEmpty()) {
+                throw new RuntimeException(
+                    "Cannot reduce capacity: This facility has " + activeReservations.size() +
+                    " active or pending reservation(s). Please ensure the new capacity can accommodate all reservations or cancel them first."
+                );
+            }
+        }
 
         facility.setName(facilityDTO.getName());
         facility.setType(FacilityType.valueOf(facilityDTO.getType().toUpperCase()));
@@ -99,6 +140,67 @@ public class FacilityService {
     @Audited(action = "DELETE", table = "facility")
     @Transactional
     public void deleteFacility(Long id) {
+        Facility facility = facilityRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Facility not found with ID: " + id));
+
+        // CRITICAL VALIDATION: Check for active or upcoming reservations
+        List<FacilityReservation> allReservations = reservationRepository.findByFacilityOrderByReservationDateAscStartTimeAsc(facility);
+
+        // Check for APPROVED reservations (confirmed bookings)
+        List<FacilityReservation> approvedReservations = allReservations.stream()
+                .filter(r -> r.getStatus() == ReservationStatus.APPROVED)
+                .collect(Collectors.toList());
+
+        if (!approvedReservations.isEmpty()) {
+            long futureCount = approvedReservations.stream()
+                    .filter(r -> r.getReservationDate().isAfter(LocalDate.now()) ||
+                                 r.getReservationDate().isEqual(LocalDate.now()))
+                    .count();
+
+            if (futureCount > 0) {
+                throw new RuntimeException(
+                    "Cannot delete facility '" + facility.getName() + "': " +
+                    "It has " + futureCount + " active or upcoming approved reservation(s). " +
+                    "Please cancel or complete all reservations before deleting this facility."
+                );
+            } else {
+                throw new RuntimeException(
+                    "Cannot delete facility '" + facility.getName() + "': " +
+                    "It has " + approvedReservations.size() + " approved reservation(s). " +
+                    "Please wait for all reservations to complete or cancel them before deleting."
+                );
+            }
+        }
+
+        // Check for PENDING reservations (awaiting approval)
+        List<FacilityReservation> pendingReservations = allReservations.stream()
+                .filter(r -> r.getStatus() == ReservationStatus.PENDING)
+                .collect(Collectors.toList());
+
+        if (!pendingReservations.isEmpty()) {
+            throw new RuntimeException(
+                "Cannot delete facility '" + facility.getName() + "': " +
+                "It has " + pendingReservations.size() + " pending reservation(s) awaiting approval. " +
+                "Please process or cancel all pending reservations before deleting this facility."
+            );
+        }
+
+        // Check for any other non-terminal reservations (WAITLISTED, OVERDUE)
+        List<FacilityReservation> otherActiveReservations = allReservations.stream()
+                .filter(r -> r.getStatus() != ReservationStatus.COMPLETED &&
+                             r.getStatus() != ReservationStatus.CANCELLED &&
+                             r.getStatus() != ReservationStatus.REJECTED)
+                .collect(Collectors.toList());
+
+        if (!otherActiveReservations.isEmpty()) {
+            throw new RuntimeException(
+                "Cannot delete facility '" + facility.getName() + "': " +
+                "It has " + otherActiveReservations.size() + " active reservation(s) in various states. " +
+                "Please ensure all reservations are cancelled, rejected, or completed before deleting."
+            );
+        }
+
+        // If we reach here, facility has no active reservations and can be safely deleted
         facilityRepository.deleteById(id);
     }
 

--- a/frontend/cefrs-frontend/src/app/components/admin/admin-dashboard/equipment/equipment.ts
+++ b/frontend/cefrs-frontend/src/app/components/admin/admin-dashboard/equipment/equipment.ts
@@ -105,7 +105,7 @@ export class Equipment implements OnInit, OnDestroy {
         error: (error) => {
           console.error('Error loading equipment:', error);
           this.isLoading = false;
-          this.displayMessage('error', 'Failed to load equipment');
+          this.displayMessage('error', 'Failed to load equipment. Please refresh the page or contact support.');
         }
       });
   }
@@ -171,7 +171,59 @@ export class Equipment implements OnInit, OnDestroy {
     this.showAddEditModal = true;
   }
 
+  /**
+   * Check if equipment can be deleted
+   */
+  canDeleteEquipment(item: EquipmentItem): boolean {
+    // Cannot delete if any items are borrowed
+    return item.quantityAvailable === item.quantityTotal && item.status !== 'BORROWED';
+  }
+
+  /**
+   * Get reason why equipment cannot be deleted
+   */
+  getDeleteBlockReason(item: EquipmentItem): string {
+    if (item.quantityAvailable < item.quantityTotal) {
+      const borrowedCount = item.quantityTotal - item.quantityAvailable;
+      return `${borrowedCount} item(s) are currently borrowed.`;
+    }
+    if (item.status === 'BORROWED') {
+      return 'This equipment is currently borrowed.';
+    }
+    return '';
+  }
+
   deleteEquipment(item: EquipmentItem): void {
+    // Frontend validation - check if any items are borrowed
+    const borrowedCount = item.quantityTotal - item.quantityAvailable;
+
+    if (borrowedCount > 0) {
+      this.displayMessage(
+        'error',
+        `Cannot delete "${item.name}" because ${borrowedCount} item(s) are currently borrowed. ` +
+        'Please wait for all items to be returned before deleting this equipment.'
+      );
+      return;
+    }
+
+    if (item.status === 'BORROWED') {
+      this.displayMessage(
+        'error',
+        `Cannot delete "${item.name}" because it is marked as borrowed. ` +
+        'Please wait for all items to be returned before attempting to delete.'
+      );
+      return;
+    }
+
+    if (item.status === 'UNAVAILABLE') {
+      this.displayMessage(
+        'error',
+        `Cannot delete "${item.name}" because it is marked as unavailable. ` +
+        'This may indicate active borrowings or maintenance. Please check the equipment status first.'
+      );
+      return;
+    }
+
     this.selectedEquipment = item;
     this.showDeleteModal = true;
   }
@@ -195,12 +247,61 @@ export class Equipment implements OnInit, OnDestroy {
   }
 
   saveAddEdit(): void {
+    // Trim all text fields
+    const trimmedName = this.equipmentForm.name.trim();
+    const trimmedDescription = this.equipmentForm.description.trim();
+    const trimmedImageUrl = this.equipmentForm.imageUrl.trim();
+
+    // Validate required fields
+    if (!trimmedName) {
+      this.displayMessage('error', 'Equipment name is required. Please enter a name for this equipment.');
+      return;
+    }
+
+    if (this.equipmentForm.quantityTotal <= 0) {
+      this.displayMessage('error', 'Quantity must be greater than 0. Please enter a valid quantity.');
+      return;
+    }
+
+    // Validate image URL if provided
+    if (trimmedImageUrl && !this.isValidUrl(trimmedImageUrl)) {
+      this.displayMessage('error', 'Invalid image URL. Please enter a valid URL starting with http:// or https://');
+      return;
+    }
+
+    // Check for duplicate names (frontend validation)
+    const duplicateName = this.equipment.find(e =>
+      e.name.toLowerCase().trim() === trimmedName.toLowerCase() &&
+      e.id !== this.equipmentForm.id
+    );
+
+    if (duplicateName) {
+      this.displayMessage(
+        'error',
+        `Equipment named "${trimmedName}" already exists. Please choose a different name.`
+      );
+      return;
+    }
+
+    // Additional validation for edit mode - check if reducing quantity below borrowed
+    if (this.isEditMode && this.selectedEquipment) {
+      const currentBorrowed = this.selectedEquipment.quantityTotal - this.selectedEquipment.quantityAvailable;
+      if (this.equipmentForm.quantityTotal < currentBorrowed) {
+        this.displayMessage(
+          'error',
+          `Cannot reduce quantity to ${this.equipmentForm.quantityTotal} because ${currentBorrowed} item(s) are currently borrowed. ` +
+          'Please ensure the new quantity is at least equal to the number of borrowed items.'
+        );
+        return;
+      }
+    }
+
     const requestData: EquipmentRequestDTO = {
-      name: this.equipmentForm.name,
+      name: trimmedName,
       category: this.equipmentForm.category,
       quantityTotal: this.equipmentForm.quantityTotal,
-      description: this.equipmentForm.description,
-      imageUrl: this.equipmentForm.imageUrl.trim(),
+      description: trimmedDescription,
+      imageUrl: trimmedImageUrl,
       status: this.equipmentForm.status
     };
 
@@ -212,11 +313,12 @@ export class Equipment implements OnInit, OnDestroy {
           next: () => {
             this.loadEquipment();
             this.closeAddEditModal();
-            this.displayMessage('success', 'Equipment updated successfully!');
+            this.displayMessage('success', `Equipment "${trimmedName}" has been updated successfully!`);
           },
           error: (error) => {
             console.error('Error updating equipment:', error);
-            this.displayMessage('error', 'Failed to update equipment');
+            const errorMessage = this.parseUpdateError(error, trimmedName);
+            this.displayMessage('error', errorMessage);
           }
         });
     } else {
@@ -227,32 +329,202 @@ export class Equipment implements OnInit, OnDestroy {
           next: () => {
             this.loadEquipment();
             this.closeAddEditModal();
-            this.displayMessage('success', 'Equipment created successfully!');
+            this.displayMessage('success', `Equipment "${trimmedName}" has been created successfully!`);
           },
           error: (error) => {
             console.error('Error creating equipment:', error);
-            this.displayMessage('error', 'Failed to create equipment');
+            const errorMessage = this.parseUpdateError(error, trimmedName);
+            this.displayMessage('error', errorMessage);
           }
         });
     }
   }
 
+  private parseUpdateError(error: any, equipmentName: string): string {
+    console.error('Update error details:', error);
+
+    // Try to extract error message from various formats
+    let errorMessage = this.extractErrorMessage(error);
+
+    if (errorMessage) {
+      const lowerError = errorMessage.toLowerCase();
+
+      // Check for specific error patterns
+      if (lowerError.includes('duplicate') || lowerError.includes('already exists') || lowerError.includes('unique constraint')) {
+        return `Equipment named "${equipmentName}" already exists in the system. Please choose a different name.`;
+      }
+
+      if (lowerError.includes('quantity') && lowerError.includes('borrowed')) {
+        return `Cannot reduce quantity: Some items are currently borrowed. ` +
+          'The new quantity must be at least equal to the number of borrowed items. ' +
+          'Please wait for items to be returned or increase the quantity.';
+      }
+
+      if (lowerError.includes('quantity') && lowerError.includes('reduce')) {
+        return `Cannot reduce quantity below the number of items currently borrowed. ` +
+          'Please ensure all borrowed items can fit within the new quantity.';
+      }
+
+      if (lowerError.includes('borrowed') || lowerError.includes('borrow')) {
+        return `Cannot modify this equipment because items are currently borrowed. ` +
+          'Please wait for all items to be returned before making changes.';
+      }
+
+      if (lowerError.includes('invalid') && lowerError.includes('quantity')) {
+        return 'The quantity value is invalid. Please enter a positive number.';
+      }
+
+      if (lowerError.includes('invalid') && lowerError.includes('category')) {
+        return 'The selected category is invalid. Please choose a valid category.';
+      }
+
+      if (lowerError.includes('invalid') && lowerError.includes('status')) {
+        return 'The selected status is invalid. Please choose a valid status option.';
+      }
+
+      // Return server message if it's descriptive and reasonable length
+      if (errorMessage.length >= 15 && errorMessage.length <= 200) {
+        return errorMessage;
+      }
+    }
+
+    // Status code based messages
+    if (error.status === 400) {
+      return 'Invalid data provided. Please check that all required fields are filled correctly and try again.';
+    }
+
+    if (error.status === 409) {
+      return `Cannot save changes to "${equipmentName}" due to a conflict. ` +
+        'This equipment may have active borrowings or reservations that prevent modifications. ' +
+        'Please check the equipment status and try again.';
+    }
+
+    if (error.status === 422) {
+      return 'The data provided cannot be processed. Please verify all fields are correct.';
+    }
+
+    if (error.status === 500) {
+      return 'A server error occurred while saving the equipment. Please try again or contact support if the problem persists.';
+    }
+
+    // Default error message
+    return `Failed to save equipment "${equipmentName}". Please verify all information is correct and try again. ` +
+      'If the problem persists, contact support for assistance.';
+  }
+
   confirmDelete(): void {
     if (this.selectedEquipment) {
+      const equipmentName = this.selectedEquipment.name;
+
       this.equipmentService.deleteEquipment(this.selectedEquipment.id)
         .pipe(takeUntil(this.destroy$))
         .subscribe({
           next: () => {
             this.loadEquipment();
             this.closeDeleteModal();
-            this.displayMessage('success', 'Equipment deleted successfully!');
+            this.displayMessage('success', `Equipment "${equipmentName}" has been deleted successfully.`);
           },
           error: (error) => {
             console.error('Error deleting equipment:', error);
-            this.displayMessage('error', 'Failed to delete equipment');
+            const errorMessage = this.parseDeleteError(error, equipmentName);
+            this.closeDeleteModal(); // Close modal even on error
+            this.displayMessage('error', errorMessage);
           }
         });
     }
+  }
+
+  private parseDeleteError(error: any, equipmentName: string): string {
+    console.error('Delete error details:', error);
+
+    // Try to extract error message from various formats
+    let errorMessage = this.extractErrorMessage(error);
+
+    if (errorMessage) {
+      const lowerError = errorMessage.toLowerCase();
+
+      // Check for specific error patterns
+      if (lowerError.includes('borrowed') || lowerError.includes('borrow')) {
+        return `Cannot delete "${equipmentName}" because items are currently borrowed. ` +
+          'Please wait for all items to be returned before attempting to delete this equipment.';
+      }
+
+      if (lowerError.includes('in use') || lowerError.includes('active')) {
+        return `Cannot delete "${equipmentName}" because it is currently in use. ` +
+          'Please ensure all items are returned and try again.';
+      }
+
+      if (lowerError.includes('reserved') || lowerError.includes('reservation')) {
+        return `Cannot delete "${equipmentName}" because it has active reservations or bookings. ` +
+          'Please cancel all reservations before deleting.';
+      }
+
+      if (lowerError.includes('foreign key') || lowerError.includes('constraint') || lowerError.includes('reference')) {
+        return `Cannot delete "${equipmentName}" because it has related records (such as borrowing history or reservations). ` +
+          'Please remove all related records first or contact support for assistance.';
+      }
+
+      if (lowerError.includes('dependency') || lowerError.includes('dependent')) {
+        return `Cannot delete "${equipmentName}" because other records depend on it. ` +
+          'Please remove dependent records first.';
+      }
+
+      // Return server message if it's descriptive and reasonable length
+      if (errorMessage.length >= 15 && errorMessage.length <= 200) {
+        return errorMessage;
+      }
+    }
+
+    // Status code based messages
+    if (error.status === 409) {
+      return `Cannot delete "${equipmentName}" because it has active borrowings or dependencies. ` +
+        'Please ensure all items are returned and no other records reference this equipment.';
+    }
+
+    if (error.status === 400) {
+      return `Cannot delete "${equipmentName}". This equipment may be in use or have active borrowings. ` +
+        'Please check the equipment status and try again.';
+    }
+
+    if (error.status === 500) {
+      return `Cannot delete "${equipmentName}" due to a server error. ` +
+        'This equipment likely has borrowing history or related records that must be handled first. ' +
+        'Please contact support if you need assistance.';
+    }
+
+    // Default error message
+    return `Failed to delete "${equipmentName}". This equipment may have active borrowings or dependencies. ` +
+      'Please ensure all items are returned and try again. If the problem persists, contact support.';
+  }
+
+  /**
+   * Extract error message from various error response formats
+   */
+  private extractErrorMessage(error: any): string {
+    // Check error.error (can be string or object)
+    if (error.error) {
+      if (typeof error.error === 'string') {
+        return error.error.trim();
+      }
+      if (error.error.message) {
+        return error.error.message.trim();
+      }
+      if (error.error.error) {
+        return error.error.error.trim();
+      }
+    }
+
+    // Check error.message
+    if (error.message && typeof error.message === 'string') {
+      return error.message.trim();
+    }
+
+    // Check statusText
+    if (error.statusText && typeof error.statusText === 'string') {
+      return error.statusText.trim();
+    }
+
+    return '';
   }
 
   closeAddEditModal(): void {

--- a/frontend/cefrs-frontend/src/app/components/admin/admin-dashboard/facilities/facilities.ts
+++ b/frontend/cefrs-frontend/src/app/components/admin/admin-dashboard/facilities/facilities.ts
@@ -87,12 +87,11 @@ export class Facilities implements OnInit, OnDestroy {
             imageUrl: f.imageUrl
           }));
           this.isLoading = false;
-
         },
         error: (error) => {
           console.error('Error loading facilities:', error);
           this.isLoading = false;
-          this.displayMessage('error', 'Failed to load facilities');
+          this.displayMessage('error', 'Failed to load facilities. Please refresh the page or contact support.');
         }
       });
   }
@@ -158,7 +157,44 @@ export class Facilities implements OnInit, OnDestroy {
     this.showAddEditModal = true;
   }
 
+  /**
+   * Check if a facility can be deleted
+   */
+  canDeleteFacility(facility: Facility): boolean {
+    return facility.status !== 'RESERVED';
+  }
+
+  /**
+   * Get reason why facility cannot be deleted
+   */
+  getDeleteBlockReason(facility: Facility): string {
+    if (facility.status === 'RESERVED') {
+      return 'This facility is currently reserved and cannot be deleted.';
+    }
+    return '';
+  }
+
   deleteFacility(facility: Facility): void {
+    // Frontend validation - prevent delete if facility is reserved
+    if (facility.status === 'RESERVED') {
+      this.displayMessage(
+        'error',
+        `Cannot delete "${facility.name}" because it is currently reserved. ` +
+        'Please cancel all active reservations first before attempting to delete this facility.'
+      );
+      return;
+    }
+
+    // Check if facility is unavailable (might have issues)
+    if (facility.status === 'UNAVAILABLE') {
+      this.displayMessage(
+        'error',
+        `Cannot delete "${facility.name}" because it is marked as unavailable. ` +
+        'This may indicate active reservations or maintenance. Please check the facility status first.'
+      );
+      return;
+    }
+
     this.selectedFacility = facility;
     this.showDeleteModal = true;
   }
@@ -170,13 +206,13 @@ export class Facilities implements OnInit, OnDestroy {
 
       // Validate file type
       if (!file.type.startsWith('image/')) {
-        this.displayMessage('error', 'Please select an image file');
+        this.displayMessage('error', 'Please select a valid image file (JPG, PNG, GIF, etc.).');
         return;
       }
 
       // Validate file size (max 5MB before compression)
       if (file.size > 5 * 1024 * 1024) {
-        this.displayMessage('error', 'File size must be less than 5MB.');
+        this.displayMessage('error', 'Image file size must be less than 5MB. Please choose a smaller image.');
         return;
       }
 
@@ -217,8 +253,6 @@ export class Facilities implements OnInit, OnDestroy {
 
         const compressedBase64 = canvas.toDataURL('image/jpeg', 0.7);
         this.photoPreview = compressedBase64;
-
-
       };
       img.src = e.target?.result as string;
     };
@@ -232,18 +266,53 @@ export class Facilities implements OnInit, OnDestroy {
   }
 
   saveAddEdit(): void {
+    // Trim all text fields
+    const trimmedName = this.facilityForm.name.trim();
+    const trimmedBuilding = this.facilityForm.building.trim();
+    const trimmedDescription = this.facilityForm.description.trim();
+
+    // Validate required fields
+    if (!trimmedName) {
+      this.displayMessage('error', 'Facility name is required. Please enter a name for this facility.');
+      return;
+    }
+
+    if (!trimmedBuilding) {
+      this.displayMessage('error', 'Building name is required. Please specify which building this facility is in.');
+      return;
+    }
+
+    if (this.facilityForm.capacity <= 0) {
+      this.displayMessage('error', 'Capacity must be greater than 0. Please enter a valid capacity.');
+      return;
+    }
+
+    // Check for duplicate names (frontend validation)
+    const duplicateName = this.facilities.find(f =>
+      f.name.toLowerCase().trim() === trimmedName.toLowerCase() &&
+      f.id !== this.facilityForm.id
+    );
+
+    if (duplicateName) {
+      this.displayMessage(
+        'error',
+        `A facility named "${trimmedName}" already exists. Please choose a different name.`
+      );
+      return;
+    }
+
     // Use preview URL if file was selected
     if (this.photoPreview && !this.facilityForm.imageUrl) {
       this.facilityForm.imageUrl = this.photoPreview;
     }
 
     const requestData = {
-      name: this.facilityForm.name,
+      name: trimmedName,
       type: this.facilityForm.type,
-      building: this.facilityForm.building,
+      building: trimmedBuilding,
       floor: this.facilityForm.floor,
       capacity: this.facilityForm.capacity,
-      description: this.facilityForm.description,
+      description: trimmedDescription,
       imageUrl: this.facilityForm.imageUrl,
       status: this.facilityForm.status
     };
@@ -256,11 +325,12 @@ export class Facilities implements OnInit, OnDestroy {
           next: () => {
             this.loadFacilities();
             this.closeAddEditModal();
-            this.displayMessage('success', 'Facility updated successfully!');
+            this.displayMessage('success', `Facility "${trimmedName}" has been updated successfully!`);
           },
           error: (error) => {
             console.error('Error updating facility:', error);
-            this.displayMessage('error', 'Failed to update facility');
+            const errorMessage = this.parseUpdateError(error, trimmedName);
+            this.displayMessage('error', errorMessage);
           }
         });
     } else {
@@ -271,32 +341,197 @@ export class Facilities implements OnInit, OnDestroy {
           next: () => {
             this.loadFacilities();
             this.closeAddEditModal();
-            this.displayMessage('success', 'Facility created successfully!');
+            this.displayMessage('success', `Facility "${trimmedName}" has been created successfully!`);
           },
           error: (error) => {
             console.error('Error creating facility:', error);
-            this.displayMessage('error', 'Failed to create facility');
+            const errorMessage = this.parseUpdateError(error, trimmedName);
+            this.displayMessage('error', errorMessage);
           }
         });
     }
   }
 
+  private parseUpdateError(error: any, facilityName: string): string {
+    console.error('Update error details:', error);
+
+    // Try to extract error message from various formats
+    let errorMessage = this.extractErrorMessage(error);
+
+    if (errorMessage) {
+      const lowerError = errorMessage.toLowerCase();
+
+      // Check for specific error patterns
+      if (lowerError.includes('duplicate') || lowerError.includes('already exists') || lowerError.includes('unique constraint')) {
+        return `A facility named "${facilityName}" already exists in the system. Please choose a different name.`;
+      }
+
+      if (lowerError.includes('capacity') && lowerError.includes('reservation')) {
+        return `Cannot reduce capacity: This facility has active reservations that require the current capacity. ` +
+          'Please cancel or modify reservations first, or increase the capacity.';
+      }
+
+      if (lowerError.includes('capacity') && lowerError.includes('reduce')) {
+        return `Cannot reduce capacity below the number of reserved seats. ` +
+          'Please ensure all reservations can accommodate the new capacity.';
+      }
+
+      if (lowerError.includes('reserved') || lowerError.includes('reservation')) {
+        return `Cannot modify this facility because it has active reservations. ` +
+          'Please wait for reservations to complete or cancel them first.';
+      }
+
+      if (lowerError.includes('invalid') && lowerError.includes('capacity')) {
+        return 'The capacity value is invalid. Please enter a positive number.';
+      }
+
+      if (lowerError.includes('invalid') && lowerError.includes('status')) {
+        return 'The selected status is invalid. Please choose a valid status option.';
+      }
+
+      // Return server message if it's descriptive and reasonable length
+      if (errorMessage.length >= 15 && errorMessage.length <= 200) {
+        return errorMessage;
+      }
+    }
+
+    // Status code based messages
+    if (error.status === 400) {
+      return 'Invalid data provided. Please check that all required fields are filled correctly and try again.';
+    }
+
+    if (error.status === 409) {
+      return `Cannot save changes to "${facilityName}" due to a conflict. ` +
+        'This facility may have active reservations that prevent modifications. ' +
+        'Please check the facility status and try again.';
+    }
+
+    if (error.status === 422) {
+      return 'The data provided cannot be processed. Please verify all fields are correct.';
+    }
+
+    if (error.status === 500) {
+      return 'A server error occurred while saving the facility. Please try again or contact support if the problem persists.';
+    }
+
+    // Default error message
+    return `Failed to save facility "${facilityName}". Please verify all information is correct and try again. ` +
+      'If the problem persists, contact support for assistance.';
+  }
+
   confirmDelete(): void {
     if (this.selectedFacility) {
+      const facilityName = this.selectedFacility.name;
+
       this.facilityService.deleteFacility(this.selectedFacility.id)
         .pipe(takeUntil(this.destroy$))
         .subscribe({
           next: () => {
             this.loadFacilities();
             this.closeDeleteModal();
-            this.displayMessage('success', 'Facility deleted successfully!');
+            this.displayMessage('success', `Facility "${facilityName}" has been deleted successfully.`);
           },
           error: (error) => {
             console.error('Error deleting facility:', error);
-            this.displayMessage('error', 'Failed to delete facility');
+            const errorMessage = this.parseDeleteError(error, facilityName);
+            this.closeDeleteModal(); // Close modal even on error
+            this.displayMessage('error', errorMessage);
           }
         });
     }
+  }
+
+  private parseDeleteError(error: any, facilityName: string): string {
+    console.error('Delete error details:', error);
+
+    // Try to extract error message from various formats
+    let errorMessage = this.extractErrorMessage(error);
+
+    if (errorMessage) {
+      const lowerError = errorMessage.toLowerCase();
+
+      // Check for specific error patterns
+      if (lowerError.includes('reserved') || lowerError.includes('reservation')) {
+        return `Cannot delete "${facilityName}" because it has active or upcoming reservations. ` +
+          'Please cancel all reservations before attempting to delete this facility.';
+      }
+
+      if (lowerError.includes('in use') || lowerError.includes('active')) {
+        return `Cannot delete "${facilityName}" because it is currently in use. ` +
+          'Please ensure the facility is not actively being used and try again.';
+      }
+
+      if (lowerError.includes('booked') || lowerError.includes('booking')) {
+        return `Cannot delete "${facilityName}" because it has active bookings. ` +
+          'Please cancel or complete all bookings before deleting.';
+      }
+
+      if (lowerError.includes('foreign key') || lowerError.includes('constraint') || lowerError.includes('reference')) {
+        return `Cannot delete "${facilityName}" because it has related records (such as reservations, bookings, or history). ` +
+          'Please remove all related records first or contact support for assistance.';
+      }
+
+      if (lowerError.includes('dependency') || lowerError.includes('dependent')) {
+        return `Cannot delete "${facilityName}" because other records depend on it. ` +
+          'Please remove dependent records first.';
+      }
+
+      // Return server message if it's descriptive and reasonable length
+      if (errorMessage.length >= 15 && errorMessage.length <= 200) {
+        return errorMessage;
+      }
+    }
+
+    // Status code based messages
+    if (error.status === 409) {
+      return `Cannot delete "${facilityName}" because it has active reservations or dependencies. ` +
+        'Please ensure all reservations are cancelled and no other records reference this facility.';
+    }
+
+    if (error.status === 400) {
+      return `Cannot delete "${facilityName}". This facility may be in use or have active reservations. ` +
+        'Please check the facility status and try again.';
+    }
+
+    if (error.status === 500) {
+      return `Cannot delete "${facilityName}" due to a server error. ` +
+        'This facility likely has related reservations or bookings that must be removed first. ' +
+        'Please contact support if you need assistance.';
+    }
+
+    // Default error message
+    return `Failed to delete "${facilityName}". This facility may have active reservations or dependencies. ` +
+      'Please ensure all reservations are cancelled and try again. If the problem persists, contact support.';
+  }
+
+  /**
+   * Extract error message from various error response formats
+   */
+  private extractErrorMessage(error: any): string {
+    // Check error.error (can be string or object)
+    if (error.error) {
+      if (typeof error.error === 'string') {
+        return error.error.trim();
+      }
+      if (error.error.message) {
+        return error.error.message.trim();
+      }
+      if (error.error.error) {
+        return error.error.error.trim();
+      }
+    }
+
+    // Check error.message
+    if (error.message && typeof error.message === 'string') {
+      return error.message.trim();
+    }
+
+    // Check statusText
+    if (error.statusText && typeof error.statusText === 'string') {
+      return error.statusText.trim();
+    }
+
+    return '';
   }
 
   closeAddEditModal(): void {


### PR DESCRIPTION
The facilities and equipment could be deleted despite having active reservations/borrowings.

This PR solves:
Backend: Validate active reservations/borrowings before deletion
Backend: Auto-update facility status based on reservation state
Frontend: Block delete attempts with clear error messages
Both: Prevent quantity/capacity reduction below active usage

For Testing:
- Deletion blocked for items in use
- Facility status auto-updates correctly
- Error messages are clear and actionable

Please test and check before you approve. Thank you!