### PR TITLE
Add suggestions modal for alternative equipment when borrowing fails

### DIFF
--- a/frontend/cefrs-frontend/src/app/components/organization/org-dashboard/equipment/equipment.html
+++ b/frontend/cefrs-frontend/src/app/components/organization/org-dashboard/equipment/equipment.html
@@ -131,6 +131,10 @@
           </svg>
           <span *ngIf="!borrowingError">Note: Your equipment request will be reviewed by an administrator.</span>
           <span *ngIf="borrowingError" class="modal-error-text">{{ borrowingError }}</span>
+          <button *ngIf="borrowingError" type="button" class="modal-btn modal-btn-alt" (click)="loadSuggestions()" [disabled]="suggestionsLoading" style="margin-left:12px">
+            <span *ngIf="suggestionsLoading">Loading alternatives...</span>
+            <span *ngIf="!suggestionsLoading">See Alternatives</span>
+          </button>
         </div>
 
         <!-- Error Message -->
@@ -160,6 +164,53 @@
     </div>
   </div>
 }
+
+  <!-- Suggestions Modal -->
+  @if (showSuggestionsModal && suggestedEquipment) {
+    <div class="modal-overlay" (click)="showSuggestionsModal = false">
+      <div class="modal-container suggestions-modal" (click)="$event.stopPropagation()">
+        <h2>Alternative Equipment Available</h2>
+
+        <div class="suggestions-info">
+          <p><strong>Requested item:</strong> {{ suggestedEquipment.unavailableEquipment.name }}</p>
+          <p><strong>Category:</strong> {{ suggestedEquipment.unavailableEquipment.category }}</p>
+          <p><strong>Requested dates:</strong> {{ suggestedEquipment.requestedBorrowDate }} → {{ suggestedEquipment.requestedReturnDate }}</p>
+          <p class="unavailable-reason"><strong>Reason:</strong> {{ suggestedEquipment.reason }}</p>
+        </div>
+
+        <div *ngIf="suggestionsLoading" class="loading-message">Loading alternatives...</div>
+
+        <div *ngIf="!suggestionsLoading && suggestedEquipment.suggestedEquipment.length === 0" class="no-suggestions-message">
+          <p>No alternative equipment available for the selected dates.</p>
+          <p>Please try a different date range.</p>
+        </div>
+
+        <div *ngIf="!suggestionsLoading && suggestedEquipment.suggestedEquipment.length > 0" class="suggestions-list">
+          <h3 class="suggestions-title">Available alternatives:</h3>
+          <div class="suggested-equipment-list">
+            <div *ngFor="let eq of suggestedEquipment.suggestedEquipment" class="suggested-equipment-card">
+              <div class="equipment-info-left">
+                <img [src]="eq.imageUrl" alt="{{ eq.name }}" class="equipment-thumb" />
+              </div>
+              <div class="equipment-info-center">
+                <h4>{{ eq.name }}</h4>
+                <p class="equipment-category">{{ eq.category }}</p>
+                <p class="equipment-qty">Available: {{ eq.quantityAvailable }} / {{ eq.quantityTotal }}</p>
+                <p class="equipment-desc">{{ eq.description }}</p>
+              </div>
+              <div class="equipment-info-right">
+                <button type="button" class="modal-btn modal-btn-submit" (click)="selectSuggestedEquipment(eq.id)">Use This Equipment</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="modal-actions">
+          <button type="button" class="modal-btn modal-btn-cancel" (click)="showSuggestionsModal = false">Close</button>
+        </div>
+      </div>
+    </div>
+  }
 
 <!-- Equipment Success Modal -->
 @if (showEquipmentSuccessModal) {

--- a/frontend/cefrs-frontend/src/app/components/organization/org-dashboard/equipment/equipment.scss
+++ b/frontend/cefrs-frontend/src/app/components/organization/org-dashboard/equipment/equipment.scss
@@ -1,4 +1,4 @@
-@import '../org-dashboard.scss';
+@use '../org-dashboard' as *;
 
 // Container for the entire equipment page
 .equipment-container {
@@ -275,4 +275,101 @@
     padding-left: $spacing-md;
     padding-right: $spacing-md;
   }
+}
+
+/* Suggestions modal styling (match student side) */
+.suggestions-modal {
+  background: linear-gradient(180deg, #ffffff 0%, #fbfbff 100%);
+  max-width: 880px;
+  width: 100%;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  box-sizing: border-box;
+  padding: $spacing-xl;
+}
+
+.suggestions-info {
+  background: $gray-lighter;
+  padding: $spacing-lg;
+  border-radius: $radius-md;
+  margin-bottom: $spacing-xl;
+  width: 100%;
+  max-width: 800px;
+  text-align: center;
+
+  p {
+    margin-bottom: $spacing-sm;
+    font-family: $font-family;
+    font-size: $font-size-base;
+    color: $text-primary;
+
+    &:last-child { margin-bottom: 0; }
+
+    strong { font-weight: $font-weight-medium; color: $text-primary; }
+  }
+
+  .unavailable-reason { color: $text-error; }
+}
+
+.suggestions-title { margin-bottom: $spacing-md; }
+
+.no-suggestions-message, .loading-message {
+  text-align: center;
+  padding: $spacing-3xl;
+  color: $text-secondary;
+  font-family: $font-family;
+  font-size: $font-size-base;
+}
+
+.suggested-equipment-list {
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-lg;
+  margin-bottom: $spacing-xl;
+  width: 100%;
+}
+
+.suggested-equipment-card {
+  display: grid;
+  grid-template-columns: 200px 1fr auto;
+  gap: $spacing-lg;
+  padding: $spacing-lg;
+  background: $white;
+  border: 2px solid $border-light;
+  border-radius: $radius-md;
+  align-items: center;
+  transition: all $transition-fast;
+}
+
+.suggested-equipment-card:hover {
+  border-color: $primary-color;
+  box-shadow: $shadow-md;
+}
+
+.equipment-thumb { width: 200px; height: 150px; object-fit: cover; border-radius: $radius-sm; overflow: hidden; }
+
+.suggested-equipment-actions { display: flex; flex-direction: column; gap: 0.5rem; align-items: flex-end; }
+
+.btn-suggestion-use {
+  background: $primary-color;
+  color: $white;
+  border: none;
+  padding: $spacing-sm $spacing-xl;
+  border-radius: $radius-sm;
+  font-size: $font-size-base;
+  font-weight: $font-weight-medium;
+  cursor: pointer;
+}
+
+@media (max-width: 900px) {
+  .suggested-equipment-list { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 520px) {
+  .suggestions-modal { padding: 1rem; }
+  .suggested-equipment-card { grid-template-columns: 72px 1fr; gap: 0.75rem; }
+  .suggested-equipment-actions { flex-direction: row; justify-content: flex-end; gap: 0.5rem; }
+  .btn-suggestion-use { min-width: 88px; padding: 0.45rem 0.7rem; }
 }

--- a/frontend/cefrs-frontend/src/app/components/organization/org-dashboard/equipment/equipment.ts
+++ b/frontend/cefrs-frontend/src/app/components/organization/org-dashboard/equipment/equipment.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { EquipmentService } from '../../../../services/equipment.service';
+import { EquipmentService, SuggestedEquipmentResponse } from '../../../../services/equipment.service';
 import { EquipmentBorrowingService, BorrowingRequest } from '../../../../services/equipment-borrowing.service';
 
 interface Equipment {
@@ -56,6 +56,11 @@ export class OrgEquipmentComponent implements OnInit {
   };
   borrowingLoading = false;
   borrowingError: string | null = null;
+
+  // Suggestions state
+  showSuggestionsModal = false;
+  suggestedEquipment: SuggestedEquipmentResponse | null = null;
+  suggestionsLoading = false;
 
   ngOnInit(): void {
     this.fetchEquipment();
@@ -161,8 +166,100 @@ export class OrgEquipmentComponent implements OnInit {
         this.borrowingLoading = false;
         this.borrowingError = this.parseServerError(err) || 'Failed to submit borrowing request';
         console.error('Error creating borrowing:', err);
+        // Try to load alternative suggestions when submission fails due to unavailability
+        this.loadSuggestions();
       }
     });
+  }
+
+  loadSuggestions(): void {
+    const equipmentId = this.borrowingForm.equipmentId || this.selectedEquipment?.id;
+    if (!equipmentId || !this.borrowingForm.borrowDate || !this.borrowingForm.expectedReturnDate) return;
+
+    this.suggestionsLoading = true;
+    this.suggestedEquipment = null;
+
+    this.equipmentService.getSuggestedEquipment(equipmentId, this.borrowingForm.borrowDate, this.borrowingForm.expectedReturnDate)
+      .subscribe({
+        next: (resp: any) => {
+          this.suggestionsLoading = false;
+          if (resp && resp.success && resp.data) {
+            this.suggestedEquipment = resp.data;
+          } else {
+            this.suggestedEquipment = {
+              unavailableEquipment: {
+                id: equipmentId,
+                name: resp?.data?.unavailableEquipment?.name || this.selectedEquipment?.name || 'Requested equipment',
+                category: resp?.data?.unavailableEquipment?.category || this.selectedEquipment?.category || '',
+                quantityTotal: resp?.data?.unavailableEquipment?.quantityTotal || 0,
+                quantityAvailable: resp?.data?.unavailableEquipment?.quantityAvailable || 0,
+                description: resp?.data?.unavailableEquipment?.description || this.selectedEquipment?.description || '',
+                imageUrl: resp?.data?.unavailableEquipment?.imageUrl || this.selectedEquipment?.imageUrl || '',
+                status: resp?.data?.unavailableEquipment?.status || ''
+              },
+              requestedBorrowDate: this.borrowingForm.borrowDate,
+              requestedReturnDate: this.borrowingForm.expectedReturnDate,
+              reason: resp?.message || 'No alternatives found for the selected dates',
+              suggestedEquipment: []
+            } as SuggestedEquipmentResponse;
+          }
+          this.showSuggestionsModal = true;
+        },
+        error: (err: any) => {
+          this.suggestionsLoading = false;
+          console.error('Error loading equipment suggestions:', err);
+          this.suggestedEquipment = {
+            unavailableEquipment: {
+              id: equipmentId,
+              name: this.selectedEquipment?.name || 'Requested equipment',
+              category: this.selectedEquipment?.category || '',
+              quantityTotal: 0,
+              quantityAvailable: 0,
+              description: '',
+              imageUrl: '',
+              status: ''
+            },
+            requestedBorrowDate: this.borrowingForm.borrowDate,
+            requestedReturnDate: this.borrowingForm.expectedReturnDate,
+            reason: 'Failed to load alternatives. Please try again later.',
+            suggestedEquipment: []
+          } as SuggestedEquipmentResponse;
+          this.showSuggestionsModal = true;
+        }
+      });
+  }
+
+  selectSuggestedEquipment(equipmentId: number): void {
+    let equipment = this.equipment.find(e => e.id === equipmentId);
+    if (!equipment && this.suggestedEquipment) {
+      const suggested = this.suggestedEquipment.suggestedEquipment.find((s: any) => s.id === equipmentId);
+      if (suggested) {
+        equipment = {
+          id: suggested.id,
+          name: suggested.name,
+          description: suggested.description,
+          category: suggested.category,
+          quantityAvailable: suggested.quantityAvailable,
+          quantityTotal: suggested.quantityTotal,
+          imageUrl: suggested.imageUrl,
+          status: suggested.status
+        } as Equipment;
+        this.equipment.unshift(equipment);
+      }
+    }
+
+    if (equipment) {
+      if (this.suggestedEquipment) {
+        if (!this.borrowingForm.borrowDate) this.borrowingForm.borrowDate = this.suggestedEquipment.requestedBorrowDate || '';
+        if (!this.borrowingForm.expectedReturnDate) this.borrowingForm.expectedReturnDate = this.suggestedEquipment.requestedReturnDate || '';
+        if (!this.borrowingForm.purpose) this.borrowingForm.purpose = this.suggestedEquipment.reason || '';
+      }
+
+      this.selectedEquipment = equipment;
+      this.borrowingForm.equipmentId = equipmentId;
+      this.showSuggestionsModal = false;
+      this.showEquipmentModal = true;
+    }
   }
 
   // Parse common server error shapes and extract a useful message


### PR DESCRIPTION
Implement a modal that displays alternative equipment options when a borrowing request fails due to unavailability. This feature enhances user experience by providing immediate alternatives, reducing frustration during the borrowing process.